### PR TITLE
field: adding sextic extension field.

### DIFF
--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
+use crate::StarkField;
 use core::{
     convert::TryFrom,
     fmt,
@@ -25,9 +26,9 @@ use utils::{
 /// field elements.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-pub struct CubeExtension<B: ExtensibleField<3>>(B, B, B);
+pub struct CubeExtension<B: ExtensibleField<3> + StarkField>(B, B, B);
 
-impl<B: ExtensibleField<3>> CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> CubeExtension<B> {
     /// Returns a new extension element instantiated from the provided base elements.
     pub fn new(a: B, b: B, c: B) -> Self {
         Self(a, b, c)
@@ -55,7 +56,7 @@ impl<B: ExtensibleField<3>> CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> FieldElement for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> FieldElement for CubeExtension<B> {
     type PositiveInteger = B::PositiveInteger;
     type BaseField = B;
 
@@ -142,7 +143,7 @@ impl<B: ExtensibleField<3>> FieldElement for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> ExtensionOf<B> for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> ExtensionOf<B> for CubeExtension<B> {
     #[inline(always)]
     fn mul_base(self, other: B) -> Self {
         let result = <B as ExtensibleField<3>>::mul_base([self.0, self.1, self.2], other);
@@ -150,7 +151,7 @@ impl<B: ExtensibleField<3>> ExtensionOf<B> for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> Randomizable for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> Randomizable for CubeExtension<B> {
     const VALUE_SIZE: usize = Self::ELEMENT_BYTES;
 
     fn from_random_bytes(bytes: &[u8]) -> Option<Self> {
@@ -158,7 +159,7 @@ impl<B: ExtensibleField<3>> Randomizable for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> fmt::Display for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> fmt::Display for CubeExtension<B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({}, {}, {})", self.0, self.1, self.2)
     }
@@ -167,7 +168,7 @@ impl<B: ExtensibleField<3>> fmt::Display for CubeExtension<B> {
 // OVERLOADED OPERATORS
 // ------------------------------------------------------------------------------------------------
 
-impl<B: ExtensibleField<3>> Add for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> Add for CubeExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -176,14 +177,14 @@ impl<B: ExtensibleField<3>> Add for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> AddAssign for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> AddAssign for CubeExtension<B> {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs
     }
 }
 
-impl<B: ExtensibleField<3>> Sub for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> Sub for CubeExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -192,14 +193,14 @@ impl<B: ExtensibleField<3>> Sub for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> SubAssign for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> SubAssign for CubeExtension<B> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
-impl<B: ExtensibleField<3>> Mul for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> Mul for CubeExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -210,14 +211,14 @@ impl<B: ExtensibleField<3>> Mul for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> MulAssign for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> MulAssign for CubeExtension<B> {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs
     }
 }
 
-impl<B: ExtensibleField<3>> Div for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> Div for CubeExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -227,14 +228,14 @@ impl<B: ExtensibleField<3>> Div for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> DivAssign for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> DivAssign for CubeExtension<B> {
     #[inline]
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs
     }
 }
 
-impl<B: ExtensibleField<3>> Neg for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> Neg for CubeExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -246,43 +247,43 @@ impl<B: ExtensibleField<3>> Neg for CubeExtension<B> {
 // TYPE CONVERSIONS
 // ------------------------------------------------------------------------------------------------
 
-impl<B: ExtensibleField<3>> From<B> for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> From<B> for CubeExtension<B> {
     fn from(value: B) -> Self {
         Self(value, B::ZERO, B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3>> From<u128> for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> From<u128> for CubeExtension<B> {
     fn from(value: u128) -> Self {
         Self(B::from(value), B::ZERO, B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3>> From<u64> for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> From<u64> for CubeExtension<B> {
     fn from(value: u64) -> Self {
         Self(B::from(value), B::ZERO, B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3>> From<u32> for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> From<u32> for CubeExtension<B> {
     fn from(value: u32) -> Self {
         Self(B::from(value), B::ZERO, B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3>> From<u16> for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> From<u16> for CubeExtension<B> {
     fn from(value: u16) -> Self {
         Self(B::from(value), B::ZERO, B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3>> From<u8> for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> From<u8> for CubeExtension<B> {
     fn from(value: u8) -> Self {
         Self(B::from(value), B::ZERO, B::ZERO)
     }
 }
 
-impl<'a, B: ExtensibleField<3>> TryFrom<&'a [u8]> for CubeExtension<B> {
+impl<'a, B: ExtensibleField<3> + StarkField> TryFrom<&'a [u8]> for CubeExtension<B> {
     type Error = DeserializationError;
 
     /// Converts a slice of bytes into a field element; returns error if the value encoded in bytes
@@ -307,7 +308,7 @@ impl<'a, B: ExtensibleField<3>> TryFrom<&'a [u8]> for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> AsBytes for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> AsBytes for CubeExtension<B> {
     fn as_bytes(&self) -> &[u8] {
         // TODO: take endianness into account
         let self_ptr: *const Self = self;
@@ -318,7 +319,7 @@ impl<B: ExtensibleField<3>> AsBytes for CubeExtension<B> {
 // SERIALIZATION / DESERIALIZATION
 // ------------------------------------------------------------------------------------------------
 
-impl<B: ExtensibleField<3>> Serializable for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> Serializable for CubeExtension<B> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target);
         self.1.write_into(target);
@@ -326,12 +327,55 @@ impl<B: ExtensibleField<3>> Serializable for CubeExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3>> Deserializable for CubeExtension<B> {
+impl<B: ExtensibleField<3> + StarkField> Deserializable for CubeExtension<B> {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let value0 = B::read_from(source)?;
         let value1 = B::read_from(source)?;
         let value2 = B::read_from(source)?;
         Ok(Self(value0, value1, value2))
+    }
+}
+
+// QUADRATIC EXTENSION TO BUILD A SEXTIC EXTENSION
+// ================================================================================================
+
+/// Defines a quadratic extension of the cubic extension field using an irreducible polynomial x² + 3.
+/// Thus, a sextic extension element is defined as α + β * φ, where φ is a root of this polynomial,
+/// and α and β are cubic extension field elements.
+
+// Implementing the extension Fp^6 as Fp^3[x] / (x^2 + 3).
+impl<B: ExtensibleField<3> + StarkField> ExtensibleField<2> for CubeExtension<B>
+where
+    Self: FieldElement<BaseField = B>,
+{
+    #[inline(always)]
+    fn mul(a: [Self; 2], b: [Self; 2]) -> [Self; 2] {
+        let a0b0 = a[0] * b[0];
+        let a1b1 = a[1] * b[1];
+        [
+            a0b0 - a1b1 - a1b1 - a1b1,
+            (a[0] + a[1]) * (b[0] + b[1]) - a0b0 - a1b1,
+        ]
+    }
+
+    #[inline(always)]
+    fn mul_base(a: [Self; 2], b: Self) -> [Self; 2] {
+        // multiplying an extension field element by a base field element requires just 2
+        // multiplications in the cubic extension field.
+        [a[0] * b, a[1] * b]
+    }
+
+    #[inline(always)]
+    fn frobenius(x: [Self; 2]) -> [Self; 2] {
+        // given x = α + β * φ
+        // frobenius(x) = frobenius(α) + frobenius(β) * frobenius(φ)
+        //              = frobenius(α) - frobenius(β) * φ
+        let a = <B as ExtensibleField<3>>::frobenius([x[0].0, x[0].1, x[0].2]);
+        let b = <B as ExtensibleField<3>>::frobenius([x[1].0, x[1].1, x[1].2]);
+        [
+            CubeExtension::<B>::new(a[0], a[1], a[2]),
+            -CubeExtension::<B>::new(b[0], b[1], b[2]),
+        ]
     }
 }
 

--- a/math/src/field/extensions/mod.rs
+++ b/math/src/field/extensions/mod.rs
@@ -9,4 +9,7 @@ pub use quadratic::QuadExtension;
 mod cubic;
 pub use cubic::CubeExtension;
 
+mod sextic;
+pub use sextic::SexticExtension;
+
 use super::{ExtensibleField, ExtensionOf, FieldElement};

--- a/math/src/field/extensions/quadratic.rs
+++ b/math/src/field/extensions/quadratic.rs
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::{ExtensibleField, ExtensionOf, FieldElement};
+use crate::StarkField;
 use core::{
     convert::TryFrom,
     fmt,
@@ -25,9 +26,9 @@ use utils::{
 /// elements.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-pub struct QuadExtension<B: ExtensibleField<2>>(B, B);
+pub struct QuadExtension<B: ExtensibleField<2> + StarkField>(B, B);
 
-impl<B: ExtensibleField<2>> QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> QuadExtension<B> {
     /// Returns a new extension element instantiated from the provided base elements.
     pub fn new(a: B, b: B) -> Self {
         Self(a, b)
@@ -55,7 +56,7 @@ impl<B: ExtensibleField<2>> QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> FieldElement for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> FieldElement for QuadExtension<B> {
     type PositiveInteger = B::PositiveInteger;
     type BaseField = B;
 
@@ -134,7 +135,7 @@ impl<B: ExtensibleField<2>> FieldElement for QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> ExtensionOf<B> for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> ExtensionOf<B> for QuadExtension<B> {
     #[inline(always)]
     fn mul_base(self, other: B) -> Self {
         let result = <B as ExtensibleField<2>>::mul_base([self.0, self.1], other);
@@ -142,7 +143,7 @@ impl<B: ExtensibleField<2>> ExtensionOf<B> for QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> Randomizable for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> Randomizable for QuadExtension<B> {
     const VALUE_SIZE: usize = Self::ELEMENT_BYTES;
 
     fn from_random_bytes(bytes: &[u8]) -> Option<Self> {
@@ -150,7 +151,7 @@ impl<B: ExtensibleField<2>> Randomizable for QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> fmt::Display for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> fmt::Display for QuadExtension<B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({}, {})", self.0, self.1)
     }
@@ -159,7 +160,7 @@ impl<B: ExtensibleField<2>> fmt::Display for QuadExtension<B> {
 // OVERLOADED OPERATORS
 // ------------------------------------------------------------------------------------------------
 
-impl<B: ExtensibleField<2>> Add for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> Add for QuadExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -168,14 +169,14 @@ impl<B: ExtensibleField<2>> Add for QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> AddAssign for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> AddAssign for QuadExtension<B> {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs
     }
 }
 
-impl<B: ExtensibleField<2>> Sub for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> Sub for QuadExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -184,14 +185,14 @@ impl<B: ExtensibleField<2>> Sub for QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> SubAssign for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> SubAssign for QuadExtension<B> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
-impl<B: ExtensibleField<2>> Mul for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> Mul for QuadExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -201,14 +202,14 @@ impl<B: ExtensibleField<2>> Mul for QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> MulAssign for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> MulAssign for QuadExtension<B> {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs
     }
 }
 
-impl<B: ExtensibleField<2>> Div for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> Div for QuadExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -218,14 +219,14 @@ impl<B: ExtensibleField<2>> Div for QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> DivAssign for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> DivAssign for QuadExtension<B> {
     #[inline]
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs
     }
 }
 
-impl<B: ExtensibleField<2>> Neg for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> Neg for QuadExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -237,43 +238,43 @@ impl<B: ExtensibleField<2>> Neg for QuadExtension<B> {
 // TYPE CONVERSIONS
 // ------------------------------------------------------------------------------------------------
 
-impl<B: ExtensibleField<2>> From<B> for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> From<B> for QuadExtension<B> {
     fn from(value: B) -> Self {
         Self(value, B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<2>> From<u128> for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> From<u128> for QuadExtension<B> {
     fn from(value: u128) -> Self {
         Self(B::from(value), B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<2>> From<u64> for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> From<u64> for QuadExtension<B> {
     fn from(value: u64) -> Self {
         Self(B::from(value), B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<2>> From<u32> for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> From<u32> for QuadExtension<B> {
     fn from(value: u32) -> Self {
         Self(B::from(value), B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<2>> From<u16> for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> From<u16> for QuadExtension<B> {
     fn from(value: u16) -> Self {
         Self(B::from(value), B::ZERO)
     }
 }
 
-impl<B: ExtensibleField<2>> From<u8> for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> From<u8> for QuadExtension<B> {
     fn from(value: u8) -> Self {
         Self(B::from(value), B::ZERO)
     }
 }
 
-impl<'a, B: ExtensibleField<2>> TryFrom<&'a [u8]> for QuadExtension<B> {
+impl<'a, B: ExtensibleField<2> + StarkField> TryFrom<&'a [u8]> for QuadExtension<B> {
     type Error = DeserializationError;
 
     /// Converts a slice of bytes into a field element; returns error if the value encoded in bytes
@@ -298,7 +299,7 @@ impl<'a, B: ExtensibleField<2>> TryFrom<&'a [u8]> for QuadExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<2>> AsBytes for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> AsBytes for QuadExtension<B> {
     fn as_bytes(&self) -> &[u8] {
         // TODO: take endianness into account
         let self_ptr: *const Self = self;
@@ -309,14 +310,14 @@ impl<B: ExtensibleField<2>> AsBytes for QuadExtension<B> {
 // SERIALIZATION / DESERIALIZATION
 // ------------------------------------------------------------------------------------------------
 
-impl<B: ExtensibleField<2>> Serializable for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> Serializable for QuadExtension<B> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target);
         self.1.write_into(target);
     }
 }
 
-impl<B: ExtensibleField<2>> Deserializable for QuadExtension<B> {
+impl<B: ExtensibleField<2> + StarkField> Deserializable for QuadExtension<B> {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let value0 = B::read_from(source)?;
         let value1 = B::read_from(source)?;

--- a/math/src/field/extensions/sextic.rs
+++ b/math/src/field/extensions/sextic.rs
@@ -1,0 +1,558 @@
+// Copyright (c) 2022 Cloudflare, Inc. and contributors.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or
+// at https://opensource.org/licenses/BSD-3-Clause
+
+use super::cubic::CubeExtension;
+use super::{ExtensibleField, ExtensionOf, FieldElement};
+use crate::StarkField;
+use core::{
+    convert::TryFrom,
+    fmt,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    slice,
+};
+use utils::{
+    collections::Vec, string::ToString, AsBytes, ByteReader, ByteWriter, Deserializable,
+    DeserializationError, Randomizable, Serializable, SliceReader,
+};
+
+// SEXTIC EXTENSION FIELD
+// ================================================================================================
+
+/// Represents an element of a sextic extension, it's implemented as a quadractic extension of
+/// a cubic extension of a [StarkField](crate::StarkField).
+///
+/// The extension element is defined as α + β * φ, where φ is a root of in irreducible polynomial
+/// defined by the implementation of the [ExtensibleField] trait, and α and β are cubic extension
+/// field elements.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub struct SexticExtension<B: ExtensibleField<3> + StarkField>(CubeExtension<B>, CubeExtension<B>);
+
+impl<B: ExtensibleField<3> + StarkField> SexticExtension<B> {
+    /// Returns a new extension element instantiated from the provided base elements.
+    pub fn new(a: CubeExtension<B>, b: CubeExtension<B>) -> Self {
+        Self(a, b)
+    }
+
+    /// Returns true if the base field specified by B type parameter supports quadratic extensions.
+    pub fn is_supported() -> bool {
+        <CubeExtension<B> as ExtensibleField<2>>::is_supported()
+    }
+
+    /// Converts a vector of cubic extension elements into a vector of elements in a sextic
+    /// extension field by fusing two adjacent cubic extension elements together. The output
+    /// vector is half the length of the source vector.
+    fn base_to_sextic_vector(source: Vec<CubeExtension<B>>) -> Vec<Self> {
+        debug_assert!(
+            source.len() % 2 == 0,
+            "source vector length must be divisible by two, but was {}",
+            source.len()
+        );
+        let mut v = core::mem::ManuallyDrop::new(source);
+        let p = v.as_mut_ptr();
+        let len = v.len() / 2;
+        let cap = v.capacity() / 2;
+        unsafe { Vec::from_raw_parts(p as *mut Self, len, cap) }
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> FieldElement for SexticExtension<B> {
+    type PositiveInteger = B::PositiveInteger;
+    type BaseField = B;
+
+    const ELEMENT_BYTES: usize = 2 * <CubeExtension<B> as FieldElement>::ELEMENT_BYTES;
+    const IS_CANONICAL: bool = <CubeExtension<B> as FieldElement>::IS_CANONICAL;
+    const ZERO: Self = Self(CubeExtension::<B>::ZERO, CubeExtension::<B>::ZERO);
+    const ONE: Self = Self(CubeExtension::<B>::ONE, CubeExtension::<B>::ZERO);
+
+    #[inline]
+    fn double(self) -> Self {
+        Self(self.0.double(), self.1.double())
+    }
+
+    #[inline]
+    fn inv(self) -> Self {
+        if self == Self::ZERO {
+            return self;
+        }
+        // inverse as in complex numbers, but norm is a^2 + 3b^2.
+        let three: CubeExtension<B> = 3u32.into();
+        let norm = (self.0 * self.0) + (three * self.1 * self.1);
+        let den = norm.inv();
+        Self(self.0 * den, (-self.1) * den)
+    }
+
+    #[inline]
+    fn conjugate(&self) -> Self {
+        let result = <CubeExtension<B> as ExtensibleField<2>>::frobenius([self.0, self.1]);
+        Self(result[0], result[1])
+    }
+
+    fn elements_as_bytes(elements: &[Self]) -> &[u8] {
+        unsafe {
+            slice::from_raw_parts(
+                elements.as_ptr() as *const u8,
+                elements.len() * Self::ELEMENT_BYTES,
+            )
+        }
+    }
+
+    unsafe fn bytes_as_elements(bytes: &[u8]) -> Result<&[Self], DeserializationError> {
+        if bytes.len() % Self::ELEMENT_BYTES != 0 {
+            return Err(DeserializationError::InvalidValue(format!(
+                "number of bytes ({}) does not divide into whole number of field elements",
+                bytes.len(),
+            )));
+        }
+
+        let p = bytes.as_ptr();
+        let len = bytes.len() / Self::ELEMENT_BYTES;
+
+        // make sure the bytes are aligned on the boundary consistent with base element alignment
+        if (p as usize) % Self::BaseField::ELEMENT_BYTES != 0 {
+            return Err(DeserializationError::InvalidValue(
+                "slice memory alignment is not valid for this field element type".to_string(),
+            ));
+        }
+
+        Ok(slice::from_raw_parts(p as *const Self, len))
+    }
+
+    fn zeroed_vector(n: usize) -> Vec<Self> {
+        // get twice the number of cubic extesnion elements, and re-interpret them as sextic
+        // extension field elements.
+        let result = CubeExtension::zeroed_vector(n * 2);
+        Self::base_to_sextic_vector(result)
+    }
+
+    fn as_base_elements(elements: &[Self]) -> &[Self::BaseField] {
+        let ptr = elements.as_ptr();
+        let len = elements.len() * 2 * 3;
+        unsafe { slice::from_raw_parts(ptr as *const Self::BaseField, len) }
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> ExtensionOf<CubeExtension<B>> for SexticExtension<B> {
+    #[inline(always)]
+    fn mul_base(self, other: CubeExtension<B>) -> Self {
+        let result = <CubeExtension<B> as ExtensibleField<2>>::mul_base([self.0, self.1], other);
+        Self(result[0], result[1])
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> ExtensionOf<B> for SexticExtension<B> {
+    #[inline(always)]
+    fn mul_base(self, other: B) -> Self {
+        let result =
+            <CubeExtension<B> as ExtensibleField<2>>::mul_base([self.0, self.1], other.into());
+        Self(result[0], result[1])
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> Randomizable for SexticExtension<B> {
+    const VALUE_SIZE: usize = Self::ELEMENT_BYTES;
+
+    fn from_random_bytes(bytes: &[u8]) -> Option<Self> {
+        Self::try_from(bytes).ok()
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> fmt::Display for SexticExtension<B> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({}, {})", self.0, self.1)
+    }
+}
+
+// OVERLOADED OPERATORS
+// ------------------------------------------------------------------------------------------------
+
+impl<B: ExtensibleField<3> + StarkField> Add for SexticExtension<B> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0, self.1 + rhs.1)
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> AddAssign for SexticExtension<B> {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> Sub for SexticExtension<B> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self(self.0 - rhs.0, self.1 - rhs.1)
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> SubAssign for SexticExtension<B> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> Mul for SexticExtension<B> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        let result =
+            <CubeExtension<B> as ExtensibleField<2>>::mul([self.0, self.1], [rhs.0, rhs.1]);
+        Self(result[0], result[1])
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> MulAssign for SexticExtension<B> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> Div for SexticExtension<B> {
+    type Output = Self;
+
+    #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, rhs: Self) -> Self {
+        self * rhs.inv()
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> DivAssign for SexticExtension<B> {
+    #[inline]
+    fn div_assign(&mut self, rhs: Self) {
+        *self = *self / rhs
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> Neg for SexticExtension<B> {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        Self(-self.0, -self.1)
+    }
+}
+
+// TYPE CONVERSIONS
+// ------------------------------------------------------------------------------------------------
+
+impl<B: ExtensibleField<3> + StarkField> From<CubeExtension<B>> for SexticExtension<B> {
+    fn from(value: CubeExtension<B>) -> Self {
+        Self(value, CubeExtension::ZERO)
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> From<B> for SexticExtension<B> {
+    fn from(value: B) -> Self {
+        Self(CubeExtension::from(value), CubeExtension::ZERO)
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> From<u128> for SexticExtension<B> {
+    fn from(value: u128) -> Self {
+        Self(CubeExtension::from(value), CubeExtension::ZERO)
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> From<u64> for SexticExtension<B> {
+    fn from(value: u64) -> Self {
+        Self(CubeExtension::from(value), CubeExtension::ZERO)
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> From<u32> for SexticExtension<B> {
+    fn from(value: u32) -> Self {
+        Self(CubeExtension::from(value), CubeExtension::ZERO)
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> From<u16> for SexticExtension<B> {
+    fn from(value: u16) -> Self {
+        Self(CubeExtension::from(value), CubeExtension::ZERO)
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> From<u8> for SexticExtension<B> {
+    fn from(value: u8) -> Self {
+        Self(CubeExtension::from(value), CubeExtension::ZERO)
+    }
+}
+impl<'a, B: ExtensibleField<3> + StarkField> TryFrom<&'a [u8]> for SexticExtension<B> {
+    type Error = DeserializationError;
+
+    /// Converts a slice of bytes into a field element; returns error if the value encoded in bytes
+    /// is not a valid field element. The bytes are assumed to be in little-endian byte order.
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() < Self::ELEMENT_BYTES {
+            return Err(DeserializationError::InvalidValue(format!(
+                "not enough bytes for a full field element; expected {} bytes, but was {} bytes",
+                Self::ELEMENT_BYTES,
+                bytes.len(),
+            )));
+        }
+        if bytes.len() > Self::ELEMENT_BYTES {
+            return Err(DeserializationError::InvalidValue(format!(
+                "too many bytes for a field element; expected {} bytes, but was {} bytes",
+                Self::ELEMENT_BYTES,
+                bytes.len(),
+            )));
+        }
+        let mut reader = SliceReader::new(bytes);
+        Self::read_from(&mut reader)
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> AsBytes for SexticExtension<B> {
+    fn as_bytes(&self) -> &[u8] {
+        // TODO: take endianness into account
+        let self_ptr: *const Self = self;
+        unsafe { slice::from_raw_parts(self_ptr as *const u8, Self::ELEMENT_BYTES) }
+    }
+}
+
+// SERIALIZATION / DESERIALIZATION
+// ------------------------------------------------------------------------------------------------
+
+impl<B: ExtensibleField<3> + StarkField> Serializable for SexticExtension<B> {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+        self.1.write_into(target);
+    }
+}
+
+impl<B: ExtensibleField<3> + StarkField> Deserializable for SexticExtension<B> {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let value0 = CubeExtension::read_from(source)?;
+        let value1 = CubeExtension::read_from(source)?;
+        Ok(Self(value0, value1))
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::{CubeExtension, DeserializationError, FieldElement, SexticExtension};
+    use crate::field::f64::BaseElement;
+    use rand_utils::rand_value;
+    use utils::AsBytes;
+
+    // BASIC ALGEBRA
+    // --------------------------------------------------------------------------------------------
+
+    #[test]
+    fn add() {
+        // identity
+        let r: SexticExtension<BaseElement> = rand_value();
+        assert_eq!(r, r + SexticExtension::<BaseElement>::ZERO);
+
+        // test random values
+        let r1: SexticExtension<BaseElement> = rand_value();
+        let r2: SexticExtension<BaseElement> = rand_value();
+
+        let expected = SexticExtension(r1.0 + r2.0, r1.1 + r2.1);
+        assert_eq!(expected, r1 + r2);
+    }
+
+    #[test]
+    fn sub() {
+        // identity
+        let r: SexticExtension<BaseElement> = rand_value();
+        assert_eq!(r, r - SexticExtension::<BaseElement>::ZERO);
+
+        // test random values
+        let r1: SexticExtension<BaseElement> = rand_value();
+        let r2: SexticExtension<BaseElement> = rand_value();
+
+        let expected = SexticExtension(r1.0 - r2.0, r1.1 - r2.1);
+        assert_eq!(expected, r1 - r2);
+    }
+
+    #[test]
+    fn div() {
+        // div by zero
+        let z = SexticExtension::<BaseElement>::ZERO;
+        assert_eq!(z, z.inv());
+
+        // one div one
+        let i = SexticExtension::<BaseElement>::ONE;
+        assert_eq!(SexticExtension::<BaseElement>::ONE, i / 1u32.into());
+
+        // test div
+        let r1: SexticExtension<BaseElement> = rand_value();
+        let r2: SexticExtension<BaseElement> = rand_value();
+
+        let expected = r1 * (r2.inv());
+        assert_eq!(expected, r1 / r2);
+
+        // test inverse
+        let r3: SexticExtension<BaseElement> = rand_value();
+        assert_eq!(SexticExtension::<BaseElement>::ONE, r3 / r3);
+    }
+
+    // INITIALIZATION
+    // --------------------------------------------------------------------------------------------
+
+    #[test]
+    fn zeroed_vector() {
+        let result = SexticExtension::<BaseElement>::zeroed_vector(6);
+        assert_eq!(6, result.len());
+        for element in result.into_iter() {
+            assert_eq!(SexticExtension::<BaseElement>::ZERO, element);
+        }
+    }
+
+    // SERIALIZATION / DESERIALIZATION
+    // --------------------------------------------------------------------------------------------
+
+    #[test]
+    fn elements_as_bytes() {
+        let source = vec![
+            SexticExtension(
+                CubeExtension::new(
+                    BaseElement::new(11).into(),
+                    BaseElement::new(12).into(),
+                    BaseElement::new(13).into(),
+                ),
+                CubeExtension::new(
+                    BaseElement::new(25).into(),
+                    BaseElement::new(26).into(),
+                    BaseElement::new(27).into(),
+                ),
+            ),
+            SexticExtension(
+                CubeExtension::new(
+                    BaseElement::new(34).into(),
+                    BaseElement::new(35).into(),
+                    BaseElement::new(36).into(),
+                ),
+                CubeExtension::new(
+                    BaseElement::new(47).into(),
+                    BaseElement::new(48).into(),
+                    BaseElement::new(49).into(),
+                ),
+            ),
+        ];
+
+        let mut expected = vec![];
+        expected.extend_from_slice(&source[0].as_bytes());
+        expected.extend_from_slice(&source[1].as_bytes());
+
+        assert_eq!(
+            expected,
+            SexticExtension::<BaseElement>::elements_as_bytes(&source)
+        );
+    }
+
+    #[test]
+    fn bytes_as_elements() {
+        let elements = vec![
+            SexticExtension(
+                CubeExtension::new(
+                    BaseElement::new(11).into(),
+                    BaseElement::new(12).into(),
+                    BaseElement::new(13).into(),
+                ),
+                CubeExtension::new(
+                    BaseElement::new(25).into(),
+                    BaseElement::new(26).into(),
+                    BaseElement::new(27).into(),
+                ),
+            ),
+            SexticExtension(
+                CubeExtension::new(
+                    BaseElement::new(34).into(),
+                    BaseElement::new(35).into(),
+                    BaseElement::new(36).into(),
+                ),
+                CubeExtension::new(
+                    BaseElement::new(47).into(),
+                    BaseElement::new(48).into(),
+                    BaseElement::new(49).into(),
+                ),
+            ),
+        ];
+
+        let mut bytes = vec![];
+        bytes.extend_from_slice(&elements[0].as_bytes());
+        bytes.extend_from_slice(&elements[1].as_bytes());
+        bytes.extend_from_slice(&BaseElement::new(77).inner().to_le_bytes());
+        let result = unsafe {
+            SexticExtension::<BaseElement>::bytes_as_elements(
+                &bytes[..2 * SexticExtension::<BaseElement>::ELEMENT_BYTES],
+            )
+        };
+        assert!(result.is_ok());
+        assert_eq!(elements, result.unwrap());
+
+        let result = unsafe { SexticExtension::<BaseElement>::bytes_as_elements(&bytes) };
+        assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
+
+        let result = unsafe { SexticExtension::<BaseElement>::bytes_as_elements(&bytes[1..]) };
+        assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
+    }
+
+    // UTILITIES
+    // --------------------------------------------------------------------------------------------
+
+    #[test]
+    fn as_base_elements() {
+        let elements = vec![
+            SexticExtension(
+                CubeExtension::new(
+                    BaseElement::new(11).into(),
+                    BaseElement::new(12).into(),
+                    BaseElement::new(13).into(),
+                ),
+                CubeExtension::new(
+                    BaseElement::new(25).into(),
+                    BaseElement::new(26).into(),
+                    BaseElement::new(27).into(),
+                ),
+            ),
+            SexticExtension(
+                CubeExtension::new(
+                    BaseElement::new(34).into(),
+                    BaseElement::new(35).into(),
+                    BaseElement::new(36).into(),
+                ),
+                CubeExtension::new(
+                    BaseElement::new(47).into(),
+                    BaseElement::new(48).into(),
+                    BaseElement::new(49).into(),
+                ),
+            ),
+        ];
+
+        let expected = vec![
+            BaseElement::new(11),
+            BaseElement::new(12),
+            BaseElement::new(13),
+            BaseElement::new(25),
+            BaseElement::new(26),
+            BaseElement::new(27),
+            BaseElement::new(34),
+            BaseElement::new(35),
+            BaseElement::new(36),
+            BaseElement::new(47),
+            BaseElement::new(48),
+            BaseElement::new(49),
+        ];
+
+        assert_eq!(
+            expected,
+            SexticExtension::<BaseElement>::as_base_elements(&elements)
+        );
+    }
+}

--- a/math/src/field/f23201/mod.rs
+++ b/math/src/field/f23201/mod.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2022 Cloudflare, Inc. and contributors.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or
+// at https://opensource.org/licenses/BSD-3-Clause
+
 //! An implementation of a 23-bit prime field with modulus $2^{23} - 2^{20} + 1$.
 
 // TODO

--- a/math/src/field/f23201/tests.rs
+++ b/math/src/field/f23201/tests.rs
@@ -1,5 +1,9 @@
-use super::{BaseElement, FieldElement, Serializable, StarkField, M};
-use crate::field::{CubeExtension, ExtensionOf, QuadExtension};
+// Copyright (c) 2022 Cloudflare, Inc. and contributors.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or
+// at https://opensource.org/licenses/BSD-3-Clause
+
+use super::{BaseElement, ExtensibleField, FieldElement, Serializable, StarkField, M};
+use crate::field::{CubeExtension, ExtensionOf, QuadExtension, SexticExtension};
 use core::convert::TryFrom;
 use num_bigint::BigUint;
 use proptest::prelude::*;
@@ -319,6 +323,103 @@ fn cube_mul_base() {
 
     let expected = a * b;
     assert_eq!(expected, a.mul_base(b0));
+}
+
+// SEXTIC EXTENSION
+// ------------------------------------------------------------------------------------------------
+#[test]
+fn sextic_mul() {
+    // identity
+    let r: SexticExtension<BaseElement> = rand_value();
+    assert_eq!(
+        <SexticExtension<BaseElement>>::ZERO,
+        r * <SexticExtension<BaseElement>>::ZERO
+    );
+    assert_eq!(r, r * <SexticExtension<BaseElement>>::ONE);
+
+    // Test multiplication
+    // a = (4127016*v^2 + 3270160*v + 1059947)*z + 3115676*v^2 + 836267*v + 2721107
+    let a = <SexticExtension<BaseElement>>::new(
+        CubeExtension::new(
+            BaseElement::new(2721107),
+            BaseElement::new(836267),
+            BaseElement::new(3115676),
+        ),
+        CubeExtension::new(
+            BaseElement::new(1059947),
+            BaseElement::new(3270160),
+            BaseElement::new(4127016),
+        ),
+    );
+    // b = (4926374*v^2 + 6440253*v + 1218328)*z + 1709256*v^2 + 2601671*v + 5930367
+    let b = <SexticExtension<BaseElement>>::new(
+        CubeExtension::new(
+            BaseElement::new(5930367),
+            BaseElement::new(2601671),
+            BaseElement::new(1709256),
+        ),
+        CubeExtension::new(
+            BaseElement::new(1218328),
+            BaseElement::new(6440253),
+            BaseElement::new(4926374),
+        ),
+    );
+    // a * b = (2586336*v^2 + 1083175*v + 6492423)*z + 5801969*v^2 + 3727067*v + 5200583
+    let expected = <SexticExtension<BaseElement>>::new(
+        CubeExtension::new(
+            BaseElement::new(5200583),
+            BaseElement::new(3727067),
+            BaseElement::new(5801969),
+        ),
+        CubeExtension::new(
+            BaseElement::new(6492423),
+            BaseElement::new(1083175),
+            BaseElement::new(2586336),
+        ),
+    );
+    assert_eq!(expected, a * b);
+}
+
+#[test]
+fn sextic_mul_base() {
+    let a = <SexticExtension<BaseElement>>::new(rand_value(), rand_value());
+    let b0 = rand_value();
+    let b = <SexticExtension<BaseElement>>::new(b0, CubeExtension::ZERO);
+
+    let expected = a * b;
+    assert_eq!(expected, a.mul_base(b0));
+}
+
+#[test]
+fn sextic_frobenius() {
+    // a = (4127016*v^2 + 3270160*v + 1059947)*z + 3115676*v^2 + 836267*v + 2721107
+    let a = vec![
+        CubeExtension::new(
+            BaseElement::new(2721107),
+            BaseElement::new(836267),
+            BaseElement::new(3115676),
+        ),
+        CubeExtension::new(
+            BaseElement::new(1059947),
+            BaseElement::new(3270160),
+            BaseElement::new(4127016),
+        ),
+    ];
+    // a.frobenius() = a^p = (3853448*v^2 + 7084157*v + 6707040)*z + 4801732*v^2 + 3629074*v + 6291822
+    let expected = <SexticExtension<BaseElement>>::new(
+        CubeExtension::new(
+            BaseElement::new(6291822),
+            BaseElement::new(3629074),
+            BaseElement::new(4801732),
+        ),
+        CubeExtension::new(
+            BaseElement::new(6707040),
+            BaseElement::new(7084157),
+            BaseElement::new(3853448),
+        ),
+    );
+    let got = <CubeExtension<BaseElement> as ExtensibleField<2>>::frobenius([a[0], a[1]]);
+    assert_eq!(expected, SexticExtension::new(got[0], got[1]));
 }
 
 // RANDOMIZED TESTS

--- a/math/src/field/mod.rs
+++ b/math/src/field/mod.rs
@@ -13,4 +13,4 @@ pub mod f23;
 pub mod f23201;
 
 mod extensions;
-pub use extensions::{CubeExtension, QuadExtension};
+pub use extensions::{CubeExtension, QuadExtension, SexticExtension};

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -250,7 +250,7 @@ pub trait StarkField: FieldElement<BaseField = Self> {
 ///
 /// Implementation of this trait implicitly defines the irreducible polynomial over which the
 /// extension field is defined.
-pub trait ExtensibleField<const N: usize>: StarkField {
+pub trait ExtensibleField<const N: usize>: FieldElement {
     /// Returns a product of `a` and `b` in the field defined by this extension.
     fn mul(a: [Self; N], b: [Self; N]) -> [Self; N];
 

--- a/math/src/lib.rs
+++ b/math/src/lib.rs
@@ -111,6 +111,7 @@ pub mod fields {
     pub use super::field::f23201;
     pub use super::field::CubeExtension;
     pub use super::field::QuadExtension;
+    pub use super::field::SexticExtension;
 }
 
 mod utils;

--- a/utils/rand/src/lib.rs
+++ b/utils/rand/src/lib.rs
@@ -23,11 +23,13 @@ mod internal {
     ///
     /// # Panics
     /// Panics if:
-    /// * A valid value requires over 32 bytes.
     /// * A valid value could not be generated after 1000 tries.
     pub fn rand_value<R: Randomizable>() -> R {
         for _ in 0..1000 {
-            let bytes = rand::thread_rng().gen::<[u8; 32]>();
+            let mut bytes = Vec::<u8>::new();
+            while bytes.len() < R::VALUE_SIZE {
+                bytes.extend_from_slice(&rand::thread_rng().gen::<[u8; 32]>());
+            }
             if let Some(value) = R::from_random_bytes(&bytes[..R::VALUE_SIZE]) {
                 return value;
             }


### PR DESCRIPTION
A sextic extension is constructed as a quadratic field
extension of a cubic extension of a prime field.

Changes:
 - Fixes traits, (a different abstraction could be better).
 - fixes random number generator
 - add licensing