### PR TITLE
Optimize proof verify, reduce inversions

### DIFF
--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -56,6 +56,7 @@ pub enum FieldExtension {
     Quadratic = 2,
     /// Composition polynomial is constructed in the cubic extension of the base field.
     Cubic = 3,
+    Sextic = 6,
 }
 
 /// STARK protocol parameters.
@@ -267,6 +268,7 @@ impl FieldExtension {
             Self::None => 1,
             Self::Quadratic => 2,
             Self::Cubic => 3,
+            Self::Sextic=>6,
         }
     }
 }
@@ -285,6 +287,7 @@ impl Deserializable for FieldExtension {
             1 => Ok(FieldExtension::None),
             2 => Ok(FieldExtension::Quadratic),
             3 => Ok(FieldExtension::Cubic),
+            6 => Ok(FieldExtension::Sextic),
             value => Err(DeserializationError::InvalidValue(format!(
                 "value {} cannot be deserialized as FieldExtension enum",
                 value

--- a/math/src/field/f128/tests.rs
+++ b/math/src/field/f128/tests.rs
@@ -116,6 +116,18 @@ fn inv() {
 }
 
 #[test]
+fn multiple_inv() {
+    // test random values
+    let x: Vec<BaseElement> = rand_vector(1000);
+    let x_inv = BaseElement::multiple_inv(&x);
+    for i in 0..x.len() {
+        let y = BaseElement::inv(x[i]);
+        assert_eq!(x_inv[i], y);
+        assert_eq!(BaseElement::ONE, x[i] * x_inv[i]);
+    }
+}
+
+#[test]
 fn conjugate() {
     let a: BaseElement = rand_value();
     let b = a.conjugate();

--- a/math/src/field/f23/mod.rs
+++ b/math/src/field/f23/mod.rs
@@ -496,6 +496,7 @@ fn exp_acc<const N: usize>(base: BaseElement, tail: BaseElement) -> BaseElement 
 
 // Returns a y with y < 2M and y = x mod M.
 // Note that in general *not*: reduce_le_2m(reduce_le_2m(x)) == x
+#[inline(always)]
 const fn reduce_le_2m(x : u32) -> u32 {
     // Note 2²³ = 2¹³ - 1 mod M. So, writing  x = x₁ 2²³ + x₂ with x₂ < 2²³
     // and x₁ < 2⁹, we have x = y (mod M) where

--- a/math/src/field/f23201/mod.rs
+++ b/math/src/field/f23201/mod.rs
@@ -511,6 +511,7 @@ fn exp_acc<const N: usize>(base: BaseElement, tail: BaseElement) -> BaseElement 
 
 // Returns a y with y < 2M and y = x mod M.
 // Note that in general *not*: reduce_le_2m(reduce_le_2m(x)) == x
+#[inline(always)]
 const fn reduce_le_2m(x: u32) -> u32 {
     // Note 2²³ = 2²° - 1 mod M. So, writing  x = x₁ 2²³ + x₂ with x₂ < 2²³
     // and x₁ < 2³, we have x = y (mod M) where

--- a/math/src/field/f62/tests.rs
+++ b/math/src/field/f62/tests.rs
@@ -8,7 +8,7 @@ use crate::field::{CubeExtension, ExtensionOf, QuadExtension};
 use core::convert::TryFrom;
 use num_bigint::BigUint;
 use proptest::prelude::*;
-use rand_utils::rand_value;
+use rand_utils::{rand_value, rand_vector};
 
 // MANUAL TESTS
 // ================================================================================================
@@ -95,6 +95,18 @@ fn inv() {
     // identity
     assert_eq!(BaseElement::ONE, BaseElement::inv(BaseElement::ONE));
     assert_eq!(BaseElement::ZERO, BaseElement::inv(BaseElement::ZERO));
+}
+
+#[test]
+fn multiple_inv() {
+    // test random values
+    let x: Vec<BaseElement> = rand_vector(1000);
+    let x_inv = BaseElement::multiple_inv(&x);
+    for i in 0..x.len() {
+        let y = BaseElement::inv(x[i]);
+        assert_eq!(x_inv[i], y);
+        assert_eq!(BaseElement::ONE, x[i] * x_inv[i]);
+    }
 }
 
 #[test]

--- a/math/src/field/f64/tests.rs
+++ b/math/src/field/f64/tests.rs
@@ -8,7 +8,7 @@ use crate::field::{CubeExtension, ExtensionOf, QuadExtension};
 use core::convert::TryFrom;
 use num_bigint::BigUint;
 use proptest::prelude::*;
-use rand_utils::rand_value;
+use rand_utils::{rand_value, rand_vector};
 
 // MANUAL TESTS
 // ================================================================================================
@@ -107,6 +107,18 @@ fn inv() {
     // identity
     assert_eq!(BaseElement::ONE, BaseElement::inv(BaseElement::ONE));
     assert_eq!(BaseElement::ZERO, BaseElement::inv(BaseElement::ZERO));
+}
+
+#[test]
+fn multiple_inv() {
+    // test random values
+    let x: Vec<BaseElement> = rand_vector(1000);
+    let x_inv = BaseElement::multiple_inv(&x);
+    for i in 0..x.len() {
+        let y = BaseElement::inv(x[i]);
+        assert_eq!(x_inv[i], y);
+        assert_eq!(BaseElement::ONE, x[i] * x_inv[i]);
+    }
 }
 
 #[test]

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -147,6 +147,24 @@ pub trait FieldElement:
     #[must_use]
     fn conjugate(&self) -> Self;
 
+    /// Returns the multiplicative inverse of each field element.
+    #[must_use]
+    fn multiple_inv(x: &[Self]) -> Vec<Self> {
+        let n = x.len();
+        let mut prod = Vec::<Self>::with_capacity(n + 1);
+        prod.push(Self::ONE);
+        for i in 0..n {
+            prod.push(prod[i] * x[i]);
+        }
+        let mut prod_inv = prod[n].inv();
+        for i in (0..n).rev() {
+            prod[i] *= prod_inv;
+            prod_inv *= x[i];
+        }
+        prod.truncate(n);
+        return prod;
+    }
+
     // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -60,7 +60,7 @@ use utils::collections::Vec;
 pub use math;
 use math::{
     fft::infer_degree,
-    fields::{CubeExtension, QuadExtension},
+    fields::{CubeExtension, QuadExtension, SexticExtension},
     ExtensibleField, FieldElement, StarkField,
 };
 
@@ -184,6 +184,16 @@ pub trait Prover {
                     HashFunction::Blake3_256 => self.generate_proof::<CubeExtension<Self::BaseField>, Blake3_256<Self::BaseField>>(trace),
                     HashFunction::Blake3_192 => self.generate_proof::<CubeExtension<Self::BaseField>, Blake3_192<Self::BaseField>>(trace),
                     HashFunction::Sha3_256 => self.generate_proof::<CubeExtension<Self::BaseField>, Sha3_256<Self::BaseField>>(trace),
+                }
+            }
+            FieldExtension::Sextic => {
+                if !<SexticExtension<Self::BaseField>>::is_supported() {
+                    return Err(ProverError::UnsupportedFieldExtension(6));
+                }
+                match self.options().hash_fn() {
+                    HashFunction::Blake3_256 => self.generate_proof::<SexticExtension<Self::BaseField>, Blake3_256<Self::BaseField>>(trace),
+                    HashFunction::Blake3_192 => self.generate_proof::<SexticExtension<Self::BaseField>, Blake3_192<Self::BaseField>>(trace),
+                    HashFunction::Sha3_256 => self.generate_proof::<SexticExtension<Self::BaseField>, Sha3_256<Self::BaseField>>(trace),
                 }
             }
         }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -41,7 +41,7 @@ pub use air::{
 
 pub use math;
 use math::{
-    fields::{CubeExtension, QuadExtension},
+    fields::{CubeExtension, QuadExtension, SexticExtension},
     FieldElement,
 };
 
@@ -159,6 +159,28 @@ pub fn verify<AIR: Air>(
                     let public_coin = RandomCoin::new(&public_coin_seed);
                     let channel = VerifierChannel::new(&air, proof)?;
                     perform_verification::<AIR, CubeExtension<AIR::BaseField>, Sha3_256<AIR::BaseField>>(air, channel, public_coin)
+                }
+            }
+        },
+        FieldExtension::Sextic => {
+            if !<SexticExtension<AIR::BaseField>>::is_supported() {
+                return Err(VerifierError::UnsupportedFieldExtension(6));
+            }
+            match air.options().hash_fn() {
+                HashFunction::Blake3_256 => {
+                    let public_coin = RandomCoin::new(&public_coin_seed);
+                    let channel = VerifierChannel::new(&air, proof)?;
+                    perform_verification::<AIR, SexticExtension<AIR::BaseField>, Blake3_256<AIR::BaseField>>(air, channel, public_coin)
+                }
+                HashFunction::Blake3_192 => {
+                    let public_coin = RandomCoin::new(&public_coin_seed);
+                    let channel = VerifierChannel::new(&air, proof)?;
+                    perform_verification::<AIR, SexticExtension<AIR::BaseField>, Blake3_192<AIR::BaseField>>(air, channel, public_coin)
+                }
+                HashFunction::Sha3_256 => {
+                    let public_coin = RandomCoin::new(&public_coin_seed);
+                    let channel = VerifierChannel::new(&air, proof)?;
+                    perform_verification::<AIR, SexticExtension<AIR::BaseField>, Sha3_256<AIR::BaseField>>(air, channel, public_coin)
                 }
             }
         },


### PR DESCRIPTION
Removes some field inversions during proof verification.

Based on top of #6 (merge that first)